### PR TITLE
separate line numbers from code

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -235,8 +235,8 @@ $(window).load(function() {
 	$('.l a').click(function(event) {
 		event.preventDefault();
 
-		var $selectedLine = $(this).parent();
-		var selectedLine = parseInt($selectedLine.attr('id'));
+		var selectedLine = $(this).parent().index() + 1;
+		var $selectedLine = $('pre.code .l').eq(selectedLine - 1);
 
 		if (event.shiftKey) {
 			if (lastLine) {

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -544,6 +544,10 @@ div.tree span.padding {
 	font-weight: bold;
 }
 
+pre.numbers {
+	float: left;
+}
+
 span.l {
 	display: block;
 }

--- a/src/source.latte
+++ b/src/source.latte
@@ -4,5 +4,7 @@
 {block title}File {$fileName}{/block}
 
 {block content}
-<pre><code>{$source|replaceRE:'~<span class="line">(\\s*(\\d+):\\s*)</span>([^\\n]*(?:\\n|$))~','<span id="$2" class="l"><a href="#$2">$1</a>$3</span>'|noescape}</code></pre>
+{var $lineRegex = '~<span class="line">(\\s*(\\d+):\\s*)</span>([^\\n]*(?:\\n|$))~'}
+<pre class="numbers"><code>{$source|replaceRE:$lineRegex,'<span class="l"><a href="#$2">$1</a></span>'|noescape}</code></pre></pre>
+<pre class="code"><code>{$source|replaceRE:$lineRegex,'<span id="$2" class="l">$3</span>'|noescape}</code></pre>
 {/block}

--- a/src/source.latte
+++ b/src/source.latte
@@ -5,6 +5,6 @@
 
 {block content}
 {var $lineRegex = '~<span class="line">(\\s*(\\d+):\\s*)</span>([^\\n]*(?:\\n|$))~'}
-<pre class="numbers"><code>{$source|replaceRE:$lineRegex,'<span class="l"><a href="#$2">$1</a></span>'|noescape}</code></pre></pre>
+<pre class="numbers"><code>{$source|replaceRE:$lineRegex,'<span class="l"><a href="#$2">$1</a></span>'|noescape}</code></pre>
 <pre class="code"><code>{$source|replaceRE:$lineRegex,'<span id="$2" class="l">$3</span>'|noescape}</code></pre>
 {/block}


### PR DESCRIPTION
Hi, I've implemented an improvement where the line numbers are separated form code in source code view. It really makes my life easier because I often copy the code from here. I'm sure everyone will appreciate this. There has nothing changed visually.
