### PR TITLE
used https for Google Search

### DIFF
--- a/src/@layout.latte
+++ b/src/@layout.latte
@@ -106,7 +106,7 @@
 
 <div id="right">
 <div id="rightInner">
-	<form{if $config->googleCseId} action="http://www.google.com/cse"{/if} id="search">
+	<form{if $config->googleCseId} action="https://www.google.com/cse"{/if} id="search">
 		<input type="hidden" name="cx" value="{$config->googleCseId}">
 		<input type="hidden" name="ie" value="UTF-8">
 		<input type="text" name="q" class="text" placeholder="Search"{if 'overview' === $active} autofocus{/if}>

--- a/src/opensearch.xml.latte
+++ b/src/opensearch.xml.latte
@@ -3,7 +3,7 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
 <ShortName>{$config->title}</ShortName>
 <Description>{$config->title} Documentation</Description>
-<Url type="text/html" method="GET" template="http://www.google.com/cse?cx={$config->googleCseId|url}&amp;ie=UTF-8&amp;q={l}searchTerms{r}"/>
+<Url type="text/html" method="GET" template="https://www.google.com/cse?cx={$config->googleCseId|url}&amp;ie=UTF-8&amp;q={l}searchTerms{r}"/>
 <Image width="16" height="16">{$config->baseUrl}/favicon.ico</Image>
 <SyndicationRight>open</SyndicationRight>
 <InputEncoding>UTF-8</InputEncoding>


### PR DESCRIPTION
This is needed when API is hosted on https, like https://api.nette.org
