### PR TITLE
PHP namespace and PHP classes are not listed in sidebar and overview

### DIFF
--- a/src/@layout.latte
+++ b/src/@layout.latte
@@ -32,6 +32,7 @@
 		{define group}
 			<ul>
 				{foreach $groups as $group}
+				{continueIf $group === 'PHP'}
 				{var $nextLevel = substr_count($iterator->nextValue, '\\') > substr_count($group, '\\')}
 				<li n:class="$actualGroup === $group || 0 === strpos($actualGroup, $group . '\\') ? active, $config->main && 0 === strpos($group, $config->main) ? main">
 					<a href="{if $groupBy === 'package'}{$group|packageUrl}{else}{$group|namespaceUrl}{/if}">
@@ -64,7 +65,7 @@
 
 		{define elements}
 			<ul>
-				<li n:foreach="$elements as $element" n:class="$activeElement === $element ? active"><a n:class="$element->deprecated ? deprecated, !$element->valid ? invalid" href="{$element|elementUrl}">{if $namespace}{$element->shortName}{else}{$element->name}{/if}</a></li>
+				<li n:foreach="$elements as $element" n:class="$activeElement === $element ? active" n:if="$element->namespaceName"><a n:class="$element->deprecated ? deprecated, !$element->valid ? invalid" href="{$element|elementUrl}">{if $namespace}{$element->shortName}{else}{$element->name}{/if}</a></li>
 			</ul>
 		{/define}
 

--- a/src/overview.latte
+++ b/src/overview.latte
@@ -12,7 +12,7 @@
 	<table class="summary" id="namespaces" n:if="$namespaces">
 		<caption>Namespaces summary</caption>
 		{foreach $namespaces as $namespace}
-			{continueIf $config->main && 0 !== strpos($namespace, $config->main)}
+			{continueIf ($config->main && 0 !== strpos($namespace, $config->main)) || $namespace === 'PHP'}
 			<tr>
 				{var $group = true}
 				<td class="name"><a href="{$namespace|namespaceUrl}">{$namespace}</a></td>


### PR DESCRIPTION
These classes (ie. native system classes) are documented because we need them to complete class tree, but they are not parts of documented project and should not be listed in sidebar and overview.
